### PR TITLE
Bump version to 0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-Unreleased
-----------
+0.2.3
+-----
 - Added highlight queries via `HIGHLIGHTS_QUERY` constant
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 
 project(tree-sitter-bpf-c
-        VERSION "0.2.2"
+        VERSION "0.2.3"
         DESCRIPTION "tree-sitter grammar for BPF C"
         HOMEPAGE_URL "https://github.com/d-e-s-o/tree-sitter-bpf-c"
         LANGUAGES C)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-bpf-c"
 description = "tree-sitter grammar for BPF C"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Daniel Müller <deso@posteo.net>"]
 license = "MIT"
 readme = "README.md"

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ endif
 
 LANGUAGE_NAME := tree-sitter-bpf-c
 HOMEPAGE_URL := https://github.com/d-e-s-o/tree-sitter-bpf-c
-VERSION := 0.2.2
+VERSION := 0.2.3
 
 # repository
 SRC_DIR := src

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tree-sitter-bpf-c",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tree-sitter-bpf-c",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "nan": "^2.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-bpf-c",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "tree-sitter grammar for BPF C",
   "repository": "https://github.com/d-e-s-o/tree-sitter-bpf-c",
   "license": "MIT",

--- a/src/parser.c
+++ b/src/parser.c
@@ -122904,7 +122904,7 @@ TS_PUBLIC const TSLanguage *tree_sitter_bpf_c(void) {
     .metadata = {
       .major_version = 0,
       .minor_version = 2,
-      .patch_version = 2,
+      .patch_version = 3,
     },
   };
   return &language;

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -14,7 +14,7 @@
     }
   ],
   "metadata": {
-    "version": "0.2.2",
+    "version": "0.2.3",
     "license": "MIT",
     "description": "tree-sitter grammar for BPF C",
     "authors": [


### PR DESCRIPTION
This change bumps the library's version to 0.2.3. The following notable changes have been made since 0.2.2:
- Added highlight queries via 'HIGHLIGHTS_QUERY' constant